### PR TITLE
fix: Show all items in Fibra Optica submenu

### DIFF
--- a/optifiber/src/public/css/Navbar.css
+++ b/optifiber/src/public/css/Navbar.css
@@ -87,7 +87,7 @@
 
 .item:focus-within .sub-menu,
 .item:hover .sub-menu {
-    max-height: 200px;
+    max-height: 400px;
     opacity: 1;
     transform: translateY(0);
     transition: max-height 0.3s ease, opacity 0.3s ease, transform 0.3s ease;


### PR DESCRIPTION
This commit fixes an issue where the 'Logs' item in the 'Fibra Óptica' submenu was not visible.

The issue was caused by the `max-height` of the submenu being too small to show all the items. This commit increases the `max-height` to `400px`.

The following changes were made:
- Modified `optifiber/src/public/css/Navbar.css` to increase the `max-height` of the `.sub-menu`.